### PR TITLE
doc: Add octodiff-docker.sh

### DIFF
--- a/bin/config-version.sh
+++ b/bin/config-version.sh
@@ -11,7 +11,7 @@ script_dir=$(dirname "$0")
 for repo_dir in "${script_dir}/../.git" /tmp/g10k/environments/jquery-puppet.git/
 do
   if [ -d "$repo_dir" ]; then
-    git --git-dir "${repo_dir}" log -1 --pretty='(%h) %cn - %s' "$1"
+    git --git-dir "${repo_dir}" log -1 --pretty='(%h) %cn - %s' -- "$1"
     exit 0
   fi
 done

--- a/bin/octodiff-docker.sh
+++ b/bin/octodiff-docker.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -euo pipefail
+
+repo_dir="$(realpath "$(dirname "$0")/..")"
+
+script=" \
+echo 'Launching debian container...' && \
+echo 'Installing packages...' && \
+apt-get update -qq && \
+DEBIAN_FRONTEND=noninteractive DEBCONF_NOWARNINGS=yes apt-get install -y -qq git octocatalog-diff puppet-agent puppet-module-puppetlabs-sshkeys-core g10k > /dev/null && \
+ \
+cd /infrastructure-puppet && \
+g10k -puppetfile -quiet && \
+echo && \
+read -p \"PuppetDB Username: \" username && \
+read -p \"PuppetDB Password: \" -s password && \
+export PUPPETDB_URL=\"https://\$username:\$password@puppet-03.ops.jquery.net:8100/\" && \
+echo -e \"\nThe octocatalog-diff command is now ready for use!\n\" && \
+/bin/bash;"
+
+# [g10k] Error: failed to create directory: vendor_modules/X
+mkdir -p "$repo_dir/vendor_modules"
+# [g10k] Error: Can't hardlink Forge module files over different devices
+# Failed to hardlink /tmp/g10k/forge/X to vendor_modules/X
+# Error: link /tmp/g10k/forge/X vendor_modules/X: invalid cross-device link
+
+mkdir -p "$repo_dir/vendor_modules/.g10kcache"
+
+docker run --rm --interactive --tty \
+  --mount type=bind,source="$repo_dir",target="/infrastructure-puppet",readonly \
+  --mount type=bind,source="$repo_dir/vendor_modules",target="/infrastructure-puppet/vendor_modules" \
+  -e "g10k_cachedir=/infrastructure-puppet/vendor_modules/.g10kcache" \
+  --entrypoint /bin/bash debian:bookworm-slim -c "$script"

--- a/doc/puppet.md
+++ b/doc/puppet.md
@@ -163,11 +163,12 @@ private repository (and remember to commit that change).
 [octocatalog-diff]: https://github.com/github/octocatalog-diff/
 
 Then, run octocatalog-diff like so:
+
 ```shell
 $ export PUPPETDB_URL="https://username:password@puppet-03.ops.jquery.net:8100/"
 
 $ octocatalog-diff -n codeorigin-02.stage.ops.jquery.net
-$ octocatalog-diff --environment production -n puppet-03.ops.jquery.net
+$ octocatalog-diff --environment production -n codeorigin-02.ops.jquery.net
 ```
 
 By default, `octocatalog-diff` will show the difference between the
@@ -176,8 +177,11 @@ current working tree and the last commit pushed to `origin`.
 `octocatalog-diff` requires a local installation of Puppet 7. On a
 Debian Bookworm (testing) setup, as of time of writing you need the
 following packages:
+
 ```
+git
 octocatalog-diff
 puppet-agent
 puppet-module-puppetlabs-sshkeys-core
+g10k
 ```


### PR DESCRIPTION
Currently:

```
PuppetDB Username: krinkle
PuppetDB Password: 
The octocatalog-diff command is now ready for use!

root@ac4aaaa39725:/infrastructure-puppet# octocatalog-diff -n codeorigin-02.stage.ops.jquery.net
#<Thread:0x00007f03a4a00218 /usr/lib/ruby/3.1.0/open3.rb:296 run> terminated with exception
	(report_on_exception is true):
/usr/lib/ruby/3.1.0/open3.rb:296:in `read': stream closed in another thread (IOError)
	from /usr/lib/ruby/3.1.0/open3.rb:296:in `block (2 levels) in capture3'
#<Thread:0x00007f03a4a00088 /usr/lib/ruby/3.1.0/open3.rb:297 run> terminated with exception
	(report_on_exception is true):
/usr/lib/ruby/3.1.0/open3.rb:297:in `read': stream closed in another thread (IOError)
	from /usr/lib/ruby/3.1.0/open3.rb:297:in `block (2 levels) in capture3'
/usr/lib/ruby/vendor_ruby/octocatalog-diff/catalog-util/bootstrap.rb:150:in `run_bootstrap':
	bootstrap failed for /tmp/ocd-ipc-20230402-3978-ovvf8x/ocd-bootstrap-checkout-20230402-3979-fu3b95:
		/tmp/ocd-ipc-20230402-3978-ovvf8x/ocd-bootstrap-checkout-20230402-3979-fu3b95
		/test_data/bootstrap.sh: line 4: g10k: command not found (OctocatalogDiff::Errors::BootstrapError)

	from /usr/lib/ruby/vendor_ruby/octocatalog-diff/catalog-util/bootstrap.rb:96:in `bootstrap_directory'
	from /usr/lib/ruby/vendor_ruby/octocatalog-diff/catalog/computed.rb:96:in `bootstrap'
	from /usr/lib/ruby/vendor_ruby/octocatalog-diff/catalog/computed.rb:113:in `build_catalog'
	from /usr/lib/ruby/vendor_ruby/octocatalog-diff/catalog.rb:96:in `build'
	from /usr/lib/ruby/vendor_ruby/octocatalog-diff/util/catalogs.rb:241:in `build_catalog'
	from /usr/lib/ruby/vendor_ruby/octocatalog-diff/util/parallel.rb:34:in `call'
	from /usr/lib/ruby/vendor_ruby/octocatalog-diff/util/parallel.rb:34:in `execute'
	from /usr/lib/ruby/vendor_ruby/octocatalog-diff/util/parallel.rb:197:in `execute_task'
	from /usr/lib/ruby/vendor_ruby/octocatalog-diff/util/parallel.rb:119:in `block (2 levels) in run_tasks_parallel'
	from /usr/lib/ruby/vendor_ruby/octocatalog-diff/util/parallel.rb:117:in `fork'
	from /usr/lib/ruby/vendor_ruby/octocatalog-diff/util/parallel.rb:117:in `block in run_tasks_parallel'
	from /usr/lib/ruby/vendor_ruby/octocatalog-diff/util/parallel.rb:114:in `each'
	from /usr/lib/ruby/vendor_ruby/octocatalog-diff/util/parallel.rb:114:in `each_with_index'
	from /usr/lib/ruby/vendor_ruby/octocatalog-diff/util/parallel.rb:114:in `run_tasks_parallel'
	from /usr/lib/ruby/vendor_ruby/octocatalog-diff/util/parallel.rb:94:in `run_tasks'
	from /usr/lib/ruby/vendor_ruby/octocatalog-diff/util/catalogs.rb:92:in `build_catalog_parallelizer'
	from /usr/lib/ruby/vendor_ruby/octocatalog-diff/util/catalogs.rb:29:in `catalogs'
	from /usr/lib/ruby/vendor_ruby/octocatalog-diff/api/v1/catalog-diff.rb:34:in `catalog_diff'
	from /usr/lib/ruby/vendor_ruby/octocatalog-diff/api/v1.rb:19:in `catalog_diff'
	from /usr/lib/ruby/vendor_ruby/octocatalog-diff/cli.rb:152:in `run_octocatalog_diff'
	from /usr/lib/ruby/vendor_ruby/octocatalog-diff/cli.rb:126:in `cli'
	from /usr/bin/octocatalog-diff:34:in `<main>'
```