### PR TITLE
filestash: remove sshd.conf to allow for legacy rsa keys

### DIFF
--- a/modules/profile/files/filestash/sshd.conf
+++ b/modules/profile/files/filestash/sshd.conf
@@ -1,3 +1,0 @@
-# Allow the old Jenkins server to log in.
-Match user filestash
-  PubkeyAcceptedAlgorithms +ssh-rsa

--- a/modules/profile/manifests/filestash.pp
+++ b/modules/profile/manifests/filestash.pp
@@ -37,10 +37,6 @@ class profile::filestash (
     }
   }
 
-  ssh::server::config { 'filestash':
-    source => 'puppet:///modules/profile/filestash/sshd.conf',
-  }
-
   $tls_config = nginx::tls_config()
 
   nginx::site { $::facts['networking']['fqdn']:


### PR DESCRIPTION
- this is no longer needed now that all filestash workflows have been migrated from jenkins to GH actions