### PR TITLE
codeorigin: add Cross-Origin-Resource-Policy header

### DIFF
--- a/modules/profile/templates/codeorigin/site.nginx.erb
+++ b/modules/profile/templates/codeorigin/site.nginx.erb
@@ -77,6 +77,12 @@ server {
     # responses during revalidation or downtime. Currently 1 year, and 7 days.
     add_header Cache-Control "public, max-age=31536000, stale-while-revalidate=604800";
     add_header Access-Control-Allow-Origin *;
+
+    # Allow users to opt in to Cross-Origin-Embedder-Policy
+    # https://github.com/jquery/infrastructure-puppet/issues/7
+    add_header Cross-Origin-Resource-Policy "cross-origin";
+
+    # Enable GZIP compression
     gzip on;
     gzip_comp_level 9;
     gzip_vary on;

--- a/test/CodeoriginTest.php
+++ b/test/CodeoriginTest.php
@@ -36,6 +36,7 @@ Unit::testHttp( $server, '/jquery-3.0.0.js', [], [
 	'cache-control' => 'public, max-age=31536000, stale-while-revalidate=604800',
 	'access-control-allow-origin' => '*',
 	'accept-ranges' => 'bytes',
+	'cross-origin-resource-policy' => 'cross-origin',
 ] );
 
 Unit::testHttp( $server, '/qunit/qunit-2.0.0.css', [], [
@@ -49,6 +50,7 @@ Unit::testHttp( $server, '/qunit/qunit-2.0.0.css', [], [
 	'cache-control' => 'public, max-age=31536000, stale-while-revalidate=604800',
 	'access-control-allow-origin' => '*',
 	'accept-ranges' => 'bytes',
+	'cross-origin-resource-policy' => 'cross-origin',
 ] );
 
 Unit::testHttp( $server, '/ui/1.10.0/themes/base/images/ui-icons_222222_256x240.png', [], [
@@ -61,6 +63,7 @@ Unit::testHttp( $server, '/ui/1.10.0/themes/base/images/ui-icons_222222_256x240.
 	'cache-control' => 'public, max-age=31536000, stale-while-revalidate=604800',
 	'access-control-allow-origin' => '*',
 	'accept-ranges' => 'bytes',
+	'cross-origin-resource-policy' => 'cross-origin',
 ] );
 
 Unit::testHttp( $server, '/jquery-2.0.0.min.map', [], [
@@ -73,6 +76,7 @@ Unit::testHttp( $server, '/jquery-2.0.0.min.map', [], [
 	'cache-control' => 'public, max-age=31536000, stale-while-revalidate=604800',
 	'access-control-allow-origin' => '*',
 	'accept-ranges' => 'bytes',
+	'cross-origin-resource-policy' => 'cross-origin',
 ] );
 
 // Static asset
@@ -90,6 +94,7 @@ Unit::testHttp( $server, '/jquery-3.0.0.js', [
 	'cache-control' => 'public, max-age=31536000, stale-while-revalidate=604800',
 	'access-control-allow-origin' => '*',
 	'accept-ranges' => 'bytes',
+	'cross-origin-resource-policy' => 'cross-origin',
 ] );
 
 // Gzip Compression
@@ -106,6 +111,7 @@ Unit::testHttp( $server, '/jquery-3.0.0.js', [
 	'etag' => '"28feccc0-40464"',
 	'cache-control' => 'public, max-age=31536000, stale-while-revalidate=604800',
 	'access-control-allow-origin' => '*',
+	'cross-origin-resource-policy' => 'cross-origin',
 ] );
 
 Unit::testHttp( $server, '/qunit/qunit-2.0.0.css', [
@@ -120,6 +126,7 @@ Unit::testHttp( $server, '/qunit/qunit-2.0.0.css', [
 	'etag' => '"28feccc0-1d20"',
 	'cache-control' => 'public, max-age=31536000, stale-while-revalidate=604800',
 	'access-control-allow-origin' => '*',
+	'cross-origin-resource-policy' => 'cross-origin',
 ] );
 
 // Renamed files


### PR DESCRIPTION
Fixes gh-7
Fixes jquery/codeorigin.jquery.com#57

I suggest rolling this out to staging only first, and we can test code2, which was recently enabled for testing the new certs.