### PR TITLE
ci: update actions to latest versions; use shas to pin versions

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -10,7 +10,7 @@ jobs:
     # Includes Ruby 2.7 and RubyGems 3.1
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
       - name: Install puppet-lint
         run: |

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -13,5 +13,5 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - run: make test


### PR DESCRIPTION
I noticed some warnings about old versions of actions/checkout today when running smoke tests. This updates both workflows and uses the SHA to pin the version.