### PR TITLE
nginx: add Content-Security-Policy-Report-Only header to all non-wordpress content sites

### DIFF
--- a/modules/profile/templates/contentorigin/site.nginx.erb
+++ b/modules/profile/templates/contentorigin/site.nginx.erb
@@ -19,6 +19,9 @@ server {
     expires 30d;
 
     add_header Access-Control-Allow-Origin "*";
+
+    # Add Content Security Policy headers
+    add_header Content-Security-Policy-Report-Only "default-src 'self'; script-src 'self' code.jquery.com; connect-src 'self'; img-src 'self'; style-src 'self'; report-to https://csp-report-api.openjs-foundation.workers.dev/";
   }
 
   location /.well-known/acme-challenge {

--- a/modules/profile/templates/contentorigin/site.nginx.erb
+++ b/modules/profile/templates/contentorigin/site.nginx.erb
@@ -13,15 +13,15 @@ server {
 
   server_tokens off;
 
+  # Add Content Security Policy headers
+  add_header Content-Security-Policy-Report-Only "default-src 'self'; script-src 'self' code.jquery.com; connect-src 'self'; img-src 'self'; style-src 'self'; report-to https://csp-report-api.openjs-foundation.workers.dev/";
+
   location / {
     root /srv/www/content.jquery.com;
 
     expires 30d;
 
     add_header Access-Control-Allow-Origin "*";
-
-    # Add Content Security Policy headers
-    add_header Content-Security-Policy-Report-Only "default-src 'self'; script-src 'self' code.jquery.com; connect-src 'self'; img-src 'self'; style-src 'self'; report-to https://csp-report-api.openjs-foundation.workers.dev/";
   }
 
   location /.well-known/acme-challenge {

--- a/modules/profile/templates/gruntjscom/site.nginx.erb
+++ b/modules/profile/templates/gruntjscom/site.nginx.erb
@@ -12,13 +12,13 @@ server {
   error_log     /var/log/nginx/error.log crit;
   server_tokens off;
 
+  # Add Content Security Policy headers
+  add_header Content-Security-Policy-Report-Only "default-src 'self'; script-src 'self' code.jquery.com; connect-src 'self'; img-src 'self'; style-src 'self'; report-to https://csp-report-api.openjs-foundation.workers.dev/";
+
   location / {
     proxy_pass http://localhost:<%= @backend_port %>;
     proxy_redirect off;
     proxy_buffering off;
-
-    # Add Content Security Policy headers
-    add_header Content-Security-Policy-Report-Only "default-src 'self'; script-src 'self' code.jquery.com; connect-src 'self'; img-src 'self'; style-src 'self'; report-to https://csp-report-api.openjs-foundation.workers.dev/";
   }
 
   location /.well-known/acme-challenge {

--- a/modules/profile/templates/gruntjscom/site.nginx.erb
+++ b/modules/profile/templates/gruntjscom/site.nginx.erb
@@ -16,6 +16,9 @@ server {
     proxy_pass http://localhost:<%= @backend_port %>;
     proxy_redirect off;
     proxy_buffering off;
+
+    # Add Content Security Policy headers
+    add_header Content-Security-Policy-Report-Only "default-src 'self'; script-src 'self' code.jquery.com; connect-src 'self'; img-src 'self'; style-src 'self'; report-to https://csp-report-api.openjs-foundation.workers.dev/";
   }
 
   location /.well-known/acme-challenge {

--- a/modules/profile/templates/miscweb/site.nginx.erb
+++ b/modules/profile/templates/miscweb/site.nginx.erb
@@ -51,6 +51,12 @@ server {
     include              /etc/nginx/fastcgi_params;
   }
 <%- end -%>
+
+  location / {
+
+    # Add Content Security Policy headers
+    add_header Content-Security-Policy-Report-Only "default-src 'self'; script-src 'self' code.jquery.com; connect-src 'self'; img-src 'self'; style-src 'self'; report-to https://csp-report-api.openjs-foundation.workers.dev/";
+  }
 }
 
 # vim: ts=2 sw=2 et

--- a/modules/profile/templates/miscweb/site.nginx.erb
+++ b/modules/profile/templates/miscweb/site.nginx.erb
@@ -18,6 +18,9 @@ server {
 
   root /srv/www/<%= @fqdn %><%= @site['webroot'] or '' %>;
 
+  # Add Content Security Policy headers
+  add_header Content-Security-Policy-Report-Only "default-src 'self'; script-src 'self' code.jquery.com; connect-src 'self'; img-src 'self'; style-src 'self'; report-to https://csp-report-api.openjs-foundation.workers.dev/";
+
 <%- if @site['allow_php'] -%>
   index index.php index.html;
   try_files $uri $uri/ /index.php$is_args$args;
@@ -51,12 +54,6 @@ server {
     include              /etc/nginx/fastcgi_params;
   }
 <%- end -%>
-
-  location / {
-
-    # Add Content Security Policy headers
-    add_header Content-Security-Policy-Report-Only "default-src 'self'; script-src 'self' code.jquery.com; connect-src 'self'; img-src 'self'; style-src 'self'; report-to https://csp-report-api.openjs-foundation.workers.dev/";
-  }
 }
 
 # vim: ts=2 sw=2 et

--- a/modules/profile/templates/wordpress/base/default-tls.nginx.erb
+++ b/modules/profile/templates/wordpress/base/default-tls.nginx.erb
@@ -20,5 +20,8 @@ server {
 
   location / {
     deny all;
+
+    # Add Content Security Policy headers
+    add_header Content-Security-Policy-Report-Only "default-src 'self'; script-src 'self' code.jquery.com; connect-src 'self'; img-src 'self'; style-src 'self'; report-to https://csp-report-api.openjs-foundation.workers.dev/";
   }
 }

--- a/modules/profile/templates/wordpress/base/default-tls.nginx.erb
+++ b/modules/profile/templates/wordpress/base/default-tls.nginx.erb
@@ -20,8 +20,5 @@ server {
 
   location / {
     deny all;
-
-    # Add Content Security Policy headers
-    add_header Content-Security-Policy-Report-Only "default-src 'self'; script-src 'self' code.jquery.com; connect-src 'self'; img-src 'self'; style-src 'self'; report-to https://csp-report-api.openjs-foundation.workers.dev/";
   }
 }


### PR DESCRIPTION
This PR adds the "Report-Only" version of the CSP header to all content sites, which has no real effect other than to send reports of violations to an API. I've set up a temporary API on cloudflare to accept those reports. We can watch the logs to determine if there are any issues that need to be addressed before switching to real CSP headers.

Fixes gh-54