### PR TITLE
nginx:grunt: move add_header to location block, add always

### DIFF
--- a/modules/profile/templates/gruntjscom/site.nginx.erb
+++ b/modules/profile/templates/gruntjscom/site.nginx.erb
@@ -12,13 +12,13 @@ server {
   error_log     /var/log/nginx/error.log crit;
   server_tokens off;
 
-  # Add Content Security Policy headers
-  add_header Content-Security-Policy-Report-Only "default-src 'self'; script-src 'self' code.jquery.com; connect-src 'self'; img-src 'self'; style-src 'self'; report-to https://csp-report-api.openjs-foundation.workers.dev/";
-
   location / {
     proxy_pass http://localhost:<%= @backend_port %>;
     proxy_redirect off;
     proxy_buffering off;
+
+    # Add Content Security Policy headers
+    add_header Content-Security-Policy-Report-Only "default-src 'self'; script-src 'self' code.jquery.com; connect-src 'self'; img-src 'self'; style-src 'self'; report-to https://csp-report-api.openjs-foundation.workers.dev/" always;
   }
 
   location /.well-known/acme-challenge {


### PR DESCRIPTION
The grunt site is unique in that it uses `proxy_pass`. Setting the header in the same location block as `proxy_pass` *should* fix it from what I've been reading. Also, I've added "always", which will send the header along even for error responses.

Ref https://github.com/jquery/infrastructure-puppet/issues/54.