### PR TITLE
CSP header refinements

### DIFF
--- a/modules/profile/templates/contentorigin/site.nginx.erb
+++ b/modules/profile/templates/contentorigin/site.nginx.erb
@@ -14,7 +14,8 @@ server {
   server_tokens off;
 
   # Add Content Security Policy headers
-  add_header Content-Security-Policy-Report-Only "default-src 'self'; script-src 'self' code.jquery.com; connect-src 'self'; img-src 'self'; style-src 'self'; report-to https://csp-report-api.openjs-foundation.workers.dev/";
+  add_header Reporting-Endpoints "csp-endpoint=\"https://csp-report-api.openjs-foundation.workers.dev/\""
+  add_header Content-Security-Policy-Report-Only "default-src 'self'; script-src 'self' code.jquery.com; connect-src 'self'; img-src 'self'; style-src 'self'; report-to csp-endpoint";
 
   location / {
     root /srv/www/content.jquery.com;

--- a/modules/profile/templates/contentorigin/site.nginx.erb
+++ b/modules/profile/templates/contentorigin/site.nginx.erb
@@ -15,7 +15,7 @@ server {
 
   # Add Content Security Policy headers
   add_header Reporting-Endpoints "csp-endpoint=\"https://csp-report-api.openjs-foundation.workers.dev/\""
-  add_header Content-Security-Policy-Report-Only "default-src 'self'; script-src 'self' code.jquery.com; connect-src 'self'; img-src 'self'; style-src 'self'; report-to csp-endpoint";
+  add_header Content-Security-Policy-Report-Only "default-src 'self'; script-src 'self' code.jquery.com; connect-src 'self'; img-src 'self'; style-src 'self'; report-uri https://csp-report-api.openjs-foundation.workers.dev/; report-to csp-endpoint";
 
   location / {
     root /srv/www/content.jquery.com;

--- a/modules/profile/templates/gruntjscom/site.nginx.erb
+++ b/modules/profile/templates/gruntjscom/site.nginx.erb
@@ -18,7 +18,8 @@ server {
     proxy_buffering off;
 
     # Add Content Security Policy headers
-    add_header Content-Security-Policy-Report-Only "default-src 'self'; script-src 'self' code.jquery.com; connect-src 'self'; img-src 'self'; style-src 'self'; report-to https://csp-report-api.openjs-foundation.workers.dev/" always;
+    add_header Reporting-Endpoints "csp-endpoint=\"https://csp-report-api.openjs-foundation.workers.dev/\""
+    add_header Content-Security-Policy-Report-Only "default-src 'self'; script-src 'self' code.jquery.com; connect-src 'self'; img-src 'self'; style-src 'self'; report-to csp-endpoint" always;
   }
 
   location /.well-known/acme-challenge {

--- a/modules/profile/templates/gruntjscom/site.nginx.erb
+++ b/modules/profile/templates/gruntjscom/site.nginx.erb
@@ -20,7 +20,7 @@ server {
     # Add Content Security Policy headers
     add_header Reporting-Endpoints "csp-endpoint=\"https://csp-report-api.openjs-foundation.workers.dev/\""
     # The SHAs are for inline GA scripts
-    add_header Content-Security-Policy-Report-Only "default-src 'self'; script-src 'self' revive.bocoup.com www.google-analytics.com 'sha256-jl/4AZjT8o/P6SGURO7MWYC9FWxqz2COCD/1XBPchLU=' 'sha256-BpeEnlj1KCWLiGFbROjXPqTiovWDb243qYdjW2miRrc='; connect-src 'self'; img-src 'self'; style-src 'self' fonts.googleapis.com; report-to csp-endpoint;" always;
+    add_header Content-Security-Policy-Report-Only "default-src 'self'; script-src 'self' revive.bocoup.com www.google-analytics.com 'sha256-jl/4AZjT8o/P6SGURO7MWYC9FWxqz2COCD/1XBPchLU=' 'sha256-BpeEnlj1KCWLiGFbROjXPqTiovWDb243qYdjW2miRrc='; connect-src 'self'; img-src 'self'; style-src 'self' fonts.googleapis.com; report-uri https://csp-report-api.openjs-foundation.workers.dev/; report-to csp-endpoint;" always;
   }
 
   location /.well-known/acme-challenge {

--- a/modules/profile/templates/gruntjscom/site.nginx.erb
+++ b/modules/profile/templates/gruntjscom/site.nginx.erb
@@ -19,7 +19,8 @@ server {
 
     # Add Content Security Policy headers
     add_header Reporting-Endpoints "csp-endpoint=\"https://csp-report-api.openjs-foundation.workers.dev/\""
-    add_header Content-Security-Policy-Report-Only "default-src 'self'; script-src 'self' code.jquery.com; connect-src 'self'; img-src 'self'; style-src 'self'; report-to csp-endpoint" always;
+    # The SHAs are for inline GA scripts
+    add_header Content-Security-Policy-Report-Only "default-src 'self'; script-src 'self' revive.bocoup.com www.google-analytics.com 'sha256-jl/4AZjT8o/P6SGURO7MWYC9FWxqz2COCD/1XBPchLU=' 'sha256-BpeEnlj1KCWLiGFbROjXPqTiovWDb243qYdjW2miRrc='; connect-src 'self'; img-src 'self'; style-src 'self' fonts.googleapis.com; report-to csp-endpoint;" always;
   }
 
   location /.well-known/acme-challenge {

--- a/modules/profile/templates/gruntjscom/site.nginx.erb
+++ b/modules/profile/templates/gruntjscom/site.nginx.erb
@@ -19,8 +19,7 @@ server {
 
     # Add Content Security Policy headers
     add_header Reporting-Endpoints "csp-endpoint=\"https://csp-report-api.openjs-foundation.workers.dev/\""
-    # The SHAs are for inline GA scripts
-    add_header Content-Security-Policy-Report-Only "default-src 'self'; script-src 'self' revive.bocoup.com www.google-analytics.com 'sha256-jl/4AZjT8o/P6SGURO7MWYC9FWxqz2COCD/1XBPchLU=' 'sha256-BpeEnlj1KCWLiGFbROjXPqTiovWDb243qYdjW2miRrc='; connect-src 'self'; img-src 'self'; style-src 'self' fonts.googleapis.com; report-uri https://csp-report-api.openjs-foundation.workers.dev/; report-to csp-endpoint;" always;
+    add_header Content-Security-Policy-Report-Only "default-src 'self'; script-src 'self'; connect-src 'self'; img-src 'self'; style-src 'self'; report-uri https://csp-report-api.openjs-foundation.workers.dev/; report-to csp-endpoint;" always;
   }
 
   location /.well-known/acme-challenge {

--- a/modules/profile/templates/miscweb/site.nginx.erb
+++ b/modules/profile/templates/miscweb/site.nginx.erb
@@ -20,7 +20,7 @@ server {
 
   # Add Content Security Policy headers
   add_header Reporting-Endpoints "csp-endpoint=\"https://csp-report-api.openjs-foundation.workers.dev/\""
-  add_header Content-Security-Policy-Report-Only "default-src 'self'; script-src 'self' code.jquery.com; connect-src 'self'; img-src 'self'; style-src 'self'; report-to csp-endpoint";
+  add_header Content-Security-Policy-Report-Only "default-src 'self'; script-src 'self' code.jquery.com; connect-src 'self'; img-src 'self'; style-src 'self'; report-uri https://csp-report-api.openjs-foundation.workers.dev/; report-to csp-endpoint";
 
 <%- if @site['allow_php'] -%>
   index index.php index.html;

--- a/modules/profile/templates/miscweb/site.nginx.erb
+++ b/modules/profile/templates/miscweb/site.nginx.erb
@@ -19,7 +19,8 @@ server {
   root /srv/www/<%= @fqdn %><%= @site['webroot'] or '' %>;
 
   # Add Content Security Policy headers
-  add_header Content-Security-Policy-Report-Only "default-src 'self'; script-src 'self' code.jquery.com; connect-src 'self'; img-src 'self'; style-src 'self'; report-to https://csp-report-api.openjs-foundation.workers.dev/";
+  add_header Reporting-Endpoints "csp-endpoint=\"https://csp-report-api.openjs-foundation.workers.dev/\""
+  add_header Content-Security-Policy-Report-Only "default-src 'self'; script-src 'self' code.jquery.com; connect-src 'self'; img-src 'self'; style-src 'self'; report-to csp-endpoint";
 
 <%- if @site['allow_php'] -%>
   index index.php index.html;


### PR DESCRIPTION
- add Reporting-Endpoints header to be used by report-to (report-uri can use URLs directly)
- specify both report-to and report-uri
- update CSP header for gruntjs.com

Ref https://github.com/jquery/infrastructure-puppet/issues/54.