### PR TITLE
nginx: add missing semicolons

### DIFF
--- a/modules/profile/templates/contentorigin/site.nginx.erb
+++ b/modules/profile/templates/contentorigin/site.nginx.erb
@@ -14,7 +14,7 @@ server {
   server_tokens off;
 
   # Add Content Security Policy headers
-  add_header Reporting-Endpoints "csp-endpoint=\"https://csp-report-api.openjs-foundation.workers.dev/\""
+  add_header Reporting-Endpoints "csp-endpoint='https://csp-report-api.openjs-foundation.workers.dev/'";
   add_header Content-Security-Policy-Report-Only "default-src 'self'; script-src 'self' code.jquery.com; connect-src 'self'; img-src 'self'; style-src 'self'; report-uri https://csp-report-api.openjs-foundation.workers.dev/; report-to csp-endpoint";
 
   location / {

--- a/modules/profile/templates/gruntjscom/site.nginx.erb
+++ b/modules/profile/templates/gruntjscom/site.nginx.erb
@@ -18,7 +18,7 @@ server {
     proxy_buffering off;
 
     # Add Content Security Policy headers
-    add_header Reporting-Endpoints "csp-endpoint=\"https://csp-report-api.openjs-foundation.workers.dev/\""
+    add_header Reporting-Endpoints "csp-endpoint='https://csp-report-api.openjs-foundation.workers.dev/'";
     add_header Content-Security-Policy-Report-Only "default-src 'self'; script-src 'self'; connect-src 'self'; img-src 'self'; style-src 'self'; report-uri https://csp-report-api.openjs-foundation.workers.dev/; report-to csp-endpoint;" always;
   }
 

--- a/modules/profile/templates/miscweb/site.nginx.erb
+++ b/modules/profile/templates/miscweb/site.nginx.erb
@@ -19,7 +19,7 @@ server {
   root /srv/www/<%= @fqdn %><%= @site['webroot'] or '' %>;
 
   # Add Content Security Policy headers
-  add_header Reporting-Endpoints "csp-endpoint=\"https://csp-report-api.openjs-foundation.workers.dev/\""
+  add_header Reporting-Endpoints "csp-endpoint='https://csp-report-api.openjs-foundation.workers.dev/'";
   add_header Content-Security-Policy-Report-Only "default-src 'self'; script-src 'self' code.jquery.com; connect-src 'self'; img-src 'self'; style-src 'self'; report-uri https://csp-report-api.openjs-foundation.workers.dev/; report-to csp-endpoint";
 
 <%- if @site['allow_php'] -%>


### PR DESCRIPTION
Ref https://github.com/jquery/infrastructure-puppet/issues/54#issuecomment-2344189423

I tested this by copying/pasting the `add_header` lines into the nginx config of a basic nginx server. Chrome and FF had both headers and were appropriately complaining about the inline style in the default page.