### PR TITLE
CSP exceptions

### DIFF
--- a/modules/profile/templates/contentorigin/site.nginx.erb
+++ b/modules/profile/templates/contentorigin/site.nginx.erb
@@ -15,7 +15,15 @@ server {
 
   # Add Content Security Policy headers
   add_header Reporting-Endpoints "csp-endpoint='https://csp-report-api.openjs-foundation.workers.dev/'";
-  add_header Content-Security-Policy-Report-Only "default-src 'self'; script-src 'self' code.jquery.com; connect-src 'self'; img-src 'self'; style-src 'self'; report-uri https://csp-report-api.openjs-foundation.workers.dev/; report-to csp-endpoint";
+  add_header Content-Security-Policy-Report-Only "
+    default-src 'self';
+    script-src 'self' code.jquery.com;
+    connect-src 'self';
+    img-src 'self';
+    style-src 'self';
+    report-uri https://csp-report-api.openjs-foundation.workers.dev/;
+    report-to csp-endpoint
+  ";
 
   location / {
     root /srv/www/content.jquery.com;

--- a/modules/profile/templates/gruntjscom/site.nginx.erb
+++ b/modules/profile/templates/gruntjscom/site.nginx.erb
@@ -19,7 +19,17 @@ server {
 
     # Add Content Security Policy headers
     add_header Reporting-Endpoints "csp-endpoint='https://csp-report-api.openjs-foundation.workers.dev/'";
-    add_header Content-Security-Policy-Report-Only "default-src 'self'; script-src 'self'; connect-src 'self'; img-src 'self'; style-src 'self'; report-uri https://csp-report-api.openjs-foundation.workers.dev/; report-to csp-endpoint;" always;
+    # script-src: add 'unsafe-eval' for the search functionality on gruntjs.com/plugins
+    # Search will need to be reimplemented to remove this exception.
+    add_header Content-Security-Policy-Report-Only "
+      default-src 'self';
+      script-src 'self' 'unsafe-eval';
+      connect-src 'self';
+      img-src 'self';
+      style-src 'self';
+      report-uri https://csp-report-api.openjs-foundation.workers.dev/;
+      report-to csp-endpoint
+    " always;
   }
 
   location /.well-known/acme-challenge {

--- a/modules/profile/templates/miscweb/site.nginx.erb
+++ b/modules/profile/templates/miscweb/site.nginx.erb
@@ -20,7 +20,20 @@ server {
 
   # Add Content Security Policy headers
   add_header Reporting-Endpoints "csp-endpoint='https://csp-report-api.openjs-foundation.workers.dev/'";
-  add_header Content-Security-Policy-Report-Only "default-src 'self'; script-src 'self' code.jquery.com; connect-src 'self'; img-src 'self'; style-src 'self'; report-uri https://csp-report-api.openjs-foundation.workers.dev/; report-to csp-endpoint";
+  # script-src: add 'wasm-unsafe-eval' for WebAssembly-driven search on
+  #   bugs.jquery.com, bugs.jqueryui.com, and plugins.jquery.com
+  # img-src: allow secure.gravatar.com images on plugins.jquery.com
+  # media-src: allow content.jquery.com media on podcast.jquery.com
+  add_header Content-Security-Policy-Report-Only "
+    default-src 'self';
+    script-src 'self' 'wasm-unsafe-eval' code.jquery.com;
+    connect-src 'self';
+    img-src 'self' secure.gravatar.com;
+    style-src 'self';
+    media-src 'self' content.jquery.com;
+    report-uri https://csp-report-api.openjs-foundation.workers.dev/;
+    report-to csp-endpoint
+  ";
 
 <%- if @site['allow_php'] -%>
   index index.php index.html;


### PR DESCRIPTION
## miscweb
- script-src: allow 'wasm-unsafe-eval' for WebAssembly-driven search on static sites
  * See [pagefind docs](https://github.com/CloudCannon/pagefind/blob/main/docs/content/docs/hosting.md#content-security-policy-csp) for more info. While the Pagefind docs say `wasm-unsafe-eval` was not yet supported in Safari, it seems to be now, according to MDN and caniuse. I'll double check this after deployment.
  * There is currently a proposal to add a `wasm-src` attribute with SRI hash validation. We should be able to add that in the future and remove the `wasm-unsafe-eval`.
- img-src: allow secure.gravatar.com images for the plugins site

## grunt
- script-src: add 'unsafe-eval' exception for plugins search
  * the datatables plugin uses jQuery's eval. While later versions of jQuery switched to using script tags for eval, it would still require an `unsafe-inline` exception. The best solution would be to re-implement search, but that would take time.

Ref #54 