### PR TITLE
miscweb: add CSP exceptions for demos and themeroller sites

### DIFF
--- a/hieradata/environments/production/roles/miscweb.yaml
+++ b/hieradata/environments/production/roles/miscweb.yaml
@@ -18,6 +18,17 @@ profile::miscweb::sites:
       name: jquery/demos.jquerymobile.com
       branch: main
     allow_php: true
+    # script-src: unsafe-eval for syntax highlighting on all pages
+    # img-src: data: for inline SVGs
+    # style-src|font-src: load fonts from Google Fonts
+    csp_header: |
+      default-src 'self';
+      script-src 'self' 'unsafe-eval';
+      img-src 'self' data:;
+      style-src 'self' fonts.googleapis.com;
+      font-src 'self' fonts.gstatic.com;
+      report-uri https://csp-report-api.openjs-foundation.workers.dev/;
+      report-to csp-endpoint
   podcast.jquery.com:
     repository:
       name: jquery/podcast.jquery.com
@@ -42,6 +53,14 @@ profile::miscweb::sites:
       }
     php_env:
       THEMEROLLER_ZIPDIR: /var/cache/themeroller-zip
+    # style-src: lots of inline styles
+    # img-src: data: for inline images
+    csp_header: |
+      default-src 'self';
+      style-src 'self' 'unsafe-inline';
+      img-src 'self' data:;
+      report-uri https://csp-report-api.openjs-foundation.workers.dev/;
+      report-to csp-endpoint
   bugs.jquery.com:
     repository:
       name: jquery/bugs.jquery.com

--- a/modules/profile/templates/miscweb/site.nginx.erb
+++ b/modules/profile/templates/miscweb/site.nginx.erb
@@ -20,6 +20,11 @@ server {
 
   # Add Content Security Policy headers
   add_header Reporting-Endpoints "csp-endpoint='https://csp-report-api.openjs-foundation.workers.dev/'";
+<%- if @site['csp_header'] -%>
+  add_header Content-Security-Policy-Report-Only "
+    <%= @site['csp_header'] %>
+  ";
+<%- else -%>
   # script-src: add 'wasm-unsafe-eval' for WebAssembly-driven search on
   #   bugs.jquery.com, bugs.jqueryui.com, and plugins.jquery.com
   # img-src: allow secure.gravatar.com images on plugins.jquery.com
@@ -34,6 +39,7 @@ server {
     report-uri https://csp-report-api.openjs-foundation.workers.dev/;
     report-to csp-endpoint
   ";
+<%- end -%>
 
 <%- if @site['allow_php'] -%>
   index index.php index.html;

--- a/modules/profile/types/miscweb/site.pp
+++ b/modules/profile/types/miscweb/site.pp
@@ -9,4 +9,5 @@ type Profile::Miscweb::Site = Struct[{
   allow_php    => Optional[Boolean],
   php_env      => Optional[Hash[String[1], String]],
   certificate  => Optional[String[1]],
+  csp_header   => Optional[String[1]],
 }]


### PR DESCRIPTION
Added CSP exceptions for 2 sites, but these sites require either `unsafe-eval` or `unsafe-inline`, which I'd prefer not to add to all sites, so I've limited them by setting them in miscweb.yaml.

**demos.jquerymobile.com**

- `script-src`: `unsafe-eval` for syntax highlighting on all pages
- `img-src`: `data:` for inline images
- `style-src`: fonts.googleapis.com for google fonts
- `font-src`: fonts.gstatic.com for google fonts

**themeroller.jquerymobile.com**

- `style-src`: `unsafe-inline` for lots of inline styles
- `img-src`: `data:` for inline images

This covers the last of all of the exceptions I've found during testing.

Ref https://github.com/jquery/infrastructure-puppet/issues/54

