### PR TITLE
miscweb: add csp exceptions for more mobile demos

### DIFF
--- a/hieradata/environments/production/roles/miscweb.yaml
+++ b/hieradata/environments/production/roles/miscweb.yaml
@@ -21,13 +21,20 @@ profile::miscweb::sites:
     # script-src: unsafe-eval for syntax highlighting on all pages
     # script-src: unsafe-inline for popup page
     # script-src: load scripts from code.jquery.com
+    # script-src: load scripts from maps.google.com
+    # script-src: load scripts from cdn.jsdelivr.net
+    # script-src: load script from gd.geobytes.com
+    # connect-src: connect to maps.googleapis.com
     # img-src: data: for inline SVGs
     # img-src: load images from code.jquery.com
+    # img-src: load images from maps.gstatic.com
+    # img-src: load images from maps.google.com
     # style-src|font-src: load fonts from Google Fonts
     # style-src: load styles from code.jquery.com
+    # style-src: load styles from cdn.jsdelivr.net
     # style-src: unsafe-inline for supports tests in
     #   jQuery 1.7.3 and jQuery Mobile 1.3.0
-    csp_header: default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline' code.jquery.com; img-src 'self' code.jquery.com data:; style-src 'self' 'unsafe-inline' code.jquery.com fonts.googleapis.com; font-src 'self' fonts.gstatic.com; report-uri https://csp-report-api.openjs-foundation.workers.dev/; report-to csp-endpoint
+    csp_header: default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline' gd.geobytes.com code.jquery.com maps.google.com cdn.jsdelivr.net; connect-src 'self' maps.googleapis.com; img-src 'self' code.jquery.com maps.gstatic.com maps.google.com data:; style-src 'self' 'unsafe-inline' code.jquery.com fonts.googleapis.com cdn.jsdelivr.net; font-src 'self' fonts.gstatic.com; report-uri https://csp-report-api.openjs-foundation.workers.dev/; report-to csp-endpoint
   podcast.jquery.com:
     repository:
       name: jquery/podcast.jquery.com


### PR DESCRIPTION
https://demos.jquerymobile.com/1.4.5/listview-autocomplete-remote/

- script-src addition for gd.geobytes.com. See https://github.com/jquery/infrastructure-puppet/issues/54#issuecomment-2521859030

https://demos.jquerymobile.com/1.5.0-rc1/map-geolocation/

- script-src, connect-src, and style-src additions for google maps

https://demos.jquerymobile.com/1.4.5/datepicker/

- script-src and style-src additions for jsdelivr assets

Ref https://github.com/jquery/infrastructure-puppet/issues/54