### PR TITLE
All: switch to non-report-only CSP headers

### DIFF
--- a/hieradata/environments/production/roles/miscweb.yaml
+++ b/hieradata/environments/production/roles/miscweb.yaml
@@ -25,6 +25,7 @@ profile::miscweb::sites:
     # script-src: load scripts from cdn.jsdelivr.net
     # script-src: load script from gd.geobytes.com
     # connect-src: connect to maps.googleapis.com
+    # connect-src: fetch fonts from fonts.googleapis.com
     # img-src: data: for inline SVGs
     # img-src: load images from code.jquery.com
     # img-src: load images from maps.gstatic.com
@@ -34,7 +35,7 @@ profile::miscweb::sites:
     # style-src: load styles from cdn.jsdelivr.net
     # style-src: unsafe-inline for supports tests in
     #   jQuery 1.7.3 and jQuery Mobile 1.3.0
-    csp_header: default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline' gd.geobytes.com code.jquery.com maps.google.com cdn.jsdelivr.net; connect-src 'self' maps.googleapis.com; img-src 'self' code.jquery.com maps.gstatic.com maps.google.com data:; style-src 'self' 'unsafe-inline' code.jquery.com fonts.googleapis.com cdn.jsdelivr.net; font-src 'self' fonts.gstatic.com; report-uri https://csp-report-api.openjs-foundation.workers.dev/; report-to csp-endpoint
+    csp_header: default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline' gd.geobytes.com code.jquery.com maps.google.com cdn.jsdelivr.net; connect-src 'self' maps.googleapis.com fonts.googleapis.com; img-src 'self' code.jquery.com maps.gstatic.com maps.google.com data:; style-src 'self' 'unsafe-inline' code.jquery.com fonts.googleapis.com cdn.jsdelivr.net; font-src 'self' fonts.gstatic.com; report-uri https://csp-report-api.openjs-foundation.workers.dev/; report-to csp-endpoint
   podcast.jquery.com:
     repository:
       name: jquery/podcast.jquery.com

--- a/modules/profile/templates/contentorigin/site.nginx.erb
+++ b/modules/profile/templates/contentorigin/site.nginx.erb
@@ -15,7 +15,7 @@ server {
 
   # Add Content Security Policy headers
   add_header Reporting-Endpoints "csp-endpoint='https://csp-report-api.openjs-foundation.workers.dev/'";
-  add_header Content-Security-Policy-Report-Only "default-src 'self'; script-src 'self' code.jquery.com; connect-src 'self'; img-src 'self'; style-src 'self'; report-uri https://csp-report-api.openjs-foundation.workers.dev/; report-to csp-endpoint";
+  add_header Content-Security-Policy "default-src 'self'; script-src 'self' code.jquery.com; connect-src 'self'; img-src 'self'; style-src 'self'; report-uri https://csp-report-api.openjs-foundation.workers.dev/; report-to csp-endpoint";
 
   location / {
     root /srv/www/content.jquery.com;

--- a/modules/profile/templates/gruntjscom/site.nginx.erb
+++ b/modules/profile/templates/gruntjscom/site.nginx.erb
@@ -21,7 +21,7 @@ server {
     add_header Reporting-Endpoints "csp-endpoint='https://csp-report-api.openjs-foundation.workers.dev/'";
     # script-src: add 'unsafe-eval' for the search functionality on gruntjs.com/plugins
     # Search will need to be reimplemented to remove this exception.
-    add_header Content-Security-Policy-Report-Only "default-src 'self'; script-src 'self' 'unsafe-eval'; connect-src 'self'; img-src 'self'; style-src 'self'; report-uri https://csp-report-api.openjs-foundation.workers.dev/; report-to csp-endpoint" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-eval'; connect-src 'self'; img-src 'self'; style-src 'self'; report-uri https://csp-report-api.openjs-foundation.workers.dev/; report-to csp-endpoint" always;
   }
 
   location /.well-known/acme-challenge {

--- a/modules/profile/templates/miscweb/site.nginx.erb
+++ b/modules/profile/templates/miscweb/site.nginx.erb
@@ -21,13 +21,13 @@ server {
   # Add Content Security Policy headers
   add_header Reporting-Endpoints "csp-endpoint='https://csp-report-api.openjs-foundation.workers.dev/'";
 <%- if @site['csp_header'] -%>
-  add_header Content-Security-Policy-Report-Only "<%= @site['csp_header'] %>";
+  add_header Content-Security-Policy "<%= @site['csp_header'] %>";
 <%- else -%>
   # script-src: add 'wasm-unsafe-eval' for WebAssembly-driven search on
   #   bugs.jquery.com, bugs.jqueryui.com, and plugins.jquery.com
   # img-src: allow secure.gravatar.com images on plugins.jquery.com
   # media-src: allow content.jquery.com media on podcast.jquery.com
-  add_header Content-Security-Policy-Report-Only "default-src 'self'; script-src 'self' 'wasm-unsafe-eval' code.jquery.com; connect-src 'self'; img-src 'self' secure.gravatar.com; style-src 'self'; media-src 'self' content.jquery.com; report-uri https://csp-report-api.openjs-foundation.workers.dev/; report-to csp-endpoint";
+  add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'wasm-unsafe-eval' code.jquery.com; connect-src 'self'; img-src 'self' secure.gravatar.com; style-src 'self'; media-src 'self' content.jquery.com; report-uri https://csp-report-api.openjs-foundation.workers.dev/; report-to csp-endpoint";
 <%- end -%>
 
 <%- if @site['allow_php'] -%>


### PR DESCRIPTION
We can continue to watch the logs for any more exceptions that need to be added.

I've found one more in the logs from the past 24 hours for the demos site (see the first commit).

Fixes gh-54