### PR TITLE
blogs: add CSP report header to blog sites

### DIFF
--- a/hieradata/environments/production/roles/blogs.yaml
+++ b/hieradata/environments/production/roles/blogs.yaml
@@ -5,6 +5,7 @@ profile::certbot::certificates:
 
 profile::wordpress::blogs::admin_email: infrastructure-team@jquery.com
 profile::wordpress::blogs::wordpress_version: ~
+profile::wordpress::blogs::csp_header: "default-src 'self'; script-src 'self' code.jquery.com; report-uri https://csp-report-api.openjs-foundation.workers.dev/; report-to csp-endpoint"
 profile::wordpress::blogs::sites:
   jquery:
     host: blog.jquery.com

--- a/modules/profile/manifests/wordpress/base.pp
+++ b/modules/profile/manifests/wordpress/base.pp
@@ -3,6 +3,7 @@ class profile::wordpress::base (
   String[1]           $innodb_buffer_pool_size = lookup('profile::wordpress::base::mariadb_innodb_buffer_pool_size', {default_value => '512M'}),
   String[1]           $wordpress_cli_version   = lookup('profile::wordpress::base::wordpress_cli_version'),
   Optional[String[1]] $default_site_cert       = lookup('profile::wordpress::base::default_site_cert', {default_value => undef}),
+  Optional[String[1]] $csp_header              = undef,
 ) {
   file { '/srv/mariadb':
     ensure => directory,

--- a/modules/profile/manifests/wordpress/blogs.pp
+++ b/modules/profile/manifests/wordpress/blogs.pp
@@ -5,8 +5,11 @@ class profile::wordpress::blogs (
   String[1]                        $db_password_seed  = lookup('profile::wordpress::blogs::db_password_seed'),
   Stdlib::Email                    $admin_email       = lookup('profile::wordpress::blogs::admin_email'),
   String[1]                        $admin_password    = lookup('profile::wordpress::blogs::admin_password'),
+  String[1]                        $csp_header        = lookup('profile::wordpress::blogs::csp_header'),
 ) {
-  include profile::wordpress::base
+  class { 'profile::wordpress::base':
+    csp_header => $csp_header,
+  }
 
   git::clone { 'blog.jquery.com-theme':
     path   => '/srv/wordpress/blog.jquery.com-theme',

--- a/modules/profile/templates/wordpress/base/default-tls.nginx.erb
+++ b/modules/profile/templates/wordpress/base/default-tls.nginx.erb
@@ -14,6 +14,12 @@ server {
 
   server_tokens off;
 
+<%- if @csp_header -%>
+  # Add Content Security Policy headers
+  add_header Reporting-Endpoints "csp-endpoint='https://csp-report-api.openjs-foundation.workers.dev/'";
+  add_header Content-Security-Policy-Report-Only "<%= @csp_header %>" always;
+<%- end -%>
+
   location /.well-known/acme-challenge {
     root /var/www/letsencrypt/;
   }


### PR DESCRIPTION
Rather than making changes to the blog wordpress theme, I've added the CSP report header for the blogs sites via nginx and the blogs yaml. Once the blog uses jquery-wp-content as its theme, we can drop this.

Ref #54 