### PR TITLE
P:builder: Don't run `npm update` or `npm prune`, run `npm ci`

### DIFF
--- a/modules/profile/files/builder/builder-do-update.sh
+++ b/modules/profile/files/builder/builder-do-update.sh
@@ -11,7 +11,11 @@ trap cleanup EXIT
 export NODE_ENV=production
 
 cd "$1"
-npm ci
+if [ -e 'package-lock.json' ] || [ -e 'npm-shrinkwrap.json' ]; then
+  npm ci
+else
+  npm install
+fi
 
 GRUNT="node_modules/.bin/grunt"
 SERVERS="$(cat /etc/builder-wordpress-hosts)"

--- a/modules/profile/files/builder/builder-do-update.sh
+++ b/modules/profile/files/builder/builder-do-update.sh
@@ -11,9 +11,7 @@ trap cleanup EXIT
 export NODE_ENV=production
 
 cd "$1"
-npm install
-npm update
-npm prune
+npm ci
 
 GRUNT="node_modules/.bin/grunt"
 SERVERS="$(cat /etc/builder-wordpress-hosts)"


### PR DESCRIPTION
Changes:
1. Use `npm ci` in favor of `npm install` whenever a lockfile is present.
2. Don't run `npm update` or `npm prune`. The latter is unnecessary, and the former is breaking the build when new incompatible dependencies come out. Also, just blindly updating everything to the latest version makes us more vulnerable to supply chain attacks in our dependencies.

Fixes gh-38