### PR TITLE
puppetserver: Disable automatic JRE updates

### DIFF
--- a/modules/profile/manifests/puppet/server.pp
+++ b/modules/profile/manifests/puppet/server.pp
@@ -7,6 +7,28 @@ class profile::puppet::server (
 ) {
   include profile::puppet::common
 
+  # Prevent automatic Java updates, as this breaks Puppet until someone we
+  # manually restart the server with `sudo systemctl restart puppetserver`
+  #
+  # Example `run-puppet-agent` output:
+  # > Error 500 on SERVER: Server Error:
+  # > Exception while executing '/etc/puppet/code/environments/production/bin/config-version.sh':
+  # > Cannot run program (in directory "."): Failed to exec spawn helper
+  #
+  # Example `systemctl status puppetserver` output:
+  # > java: Incorrect Java version: 17.0.X
+  # > java: jspawnhelper version 17.0.Y
+  # > java: This command is not for general use and should only be run as the result of
+  # > java: ProcessBuilder.start() or Runtime.exec() in a java application
+  #
+  # https://github.com/jquery/infrastructure-puppet/issues/76
+  apt::conf { 'unattended-upgrades-exclude-java':
+    priority => 60,
+    # Use trailing '::' in apt.conf key, to append to potentially entries in other files
+    # https://linux.die.net/man/5/apt.conf
+    content  => 'Unattended-Upgrade::Package-Blacklist:: "openjdk-";',
+  }
+
   stdlib::ensure_packages([
     'rsync',
   ])


### PR DESCRIPTION
Follows-up bb98142705bbb6, which added a firewall to the puppetserver so that running an outdated Java version is less of an issue.

Based on https://gerrit.wikimedia.org/r/c/operations/puppet/+/1140572 and https://gerrit.wikimedia.org/r/c/operations/puppet/+/1137224 which addresses the same issue at Wikimedia.

Ref https://github.com/jquery/infrastructure-puppet/issues/76.