### PR TITLE
P:wordpress::docs: Update the jQuery NES HeroDevs link

### DIFF
--- a/modules/profile/templates/wordpress/docs/jquery-config.php.erb
+++ b/modules/profile/templates/wordpress/docs/jquery-config.php.erb
@@ -18,7 +18,7 @@ if ( defined( 'XMLRPC_REQUEST' ) ) {
 <%- if @live_site == 'jquery.com' || @live_site == 'api.jquery.com' -%>
 define(
   'JQUERY_BANNER',
-  'jQuery 4.0 has been released! jQuery 3.x will now only receive critical updates. Find support for earlier versions at <a href="https://www.herodevs.com/support/jquery-nes">herodevs.com</a>.'
+  'jQuery 4.0 has been released! jQuery 3.x will now only receive critical updates. Find support for earlier versions at <a href="https://www.herodevs.com/support/jquery-nes?utm_source=jQuery&amp;utm_medium=link&amp;utm_campaign=eol_support_jQuery">herodevs.com</a>.'
 );
 <%- elsif @live_site == 'jquerymobile.com' || @live_site == 'api.jquerymobile.com' -%>
 define(


### PR DESCRIPTION
In a few places on the jquery.com site we already use those parameters to better attribute sources for visits to the HeroDevs jQuery NES website, but we haven't been doing that in the page header. That is now addressed.